### PR TITLE
Build docker images with branch name intact.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,10 @@ set -ex
 # LOCAL_REGISTRY="registry.dev.appgoto.com"
 LOCAL_REGISTRY="${LOCAL_REGISTRY:-registry.dev.appgoto.com}"
 
+GIT_BRNCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_SHA=$(git rev-parse HEAD | cut -c 1-8)
 
-IMAGE="${LOCAL_REGISTRY}/gfs-subscriber:latest-$GIT_SHA"
+IMAGE="${LOCAL_REGISTRY}/gfs-subscriber:${GIT_BRNCH}-${GIT_SHA}"
 LATEST_IMAGE="${LOCAL_REGISTRY}/gfs-subscriber:latest"
 
 docker build -t $IMAGE -f Dockerfile .


### PR DESCRIPTION
This push script should also tag images with branch name so we know what it was built and pushed from.